### PR TITLE
Add MiniMax H3 1K prompt dataset to the AI video model resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Don't trust a maker's own demo reel — check independent evals before committin
 - **[VBench / VBench-2.0](https://github.com/Vchitect/VBench)** — 16-dimension automated quality benchmark
 - **Artificial Analysis Video Arena** — Elo-style human-preference leaderboard across commercial + open models
 - **Video-Bench** — human-aligned evaluation suite
+- **[MiniMax H3 1K prompt dataset](https://neta.art/use-cases/en/h3-1000-prompt-list)** — 1,000 annotated text-to-video prompts: 3-field structure anatomy, 10 reusable prompts, H3 vs. peer model comparison.
 
 ## How to choose
 


### PR DESCRIPTION
Alongside the AI video model comparisons collected here, this curated 1K text-to-video prompt dataset adds the prompt side of the picture: 3-field prompt-structure anatomy, 10 hand-picked reusable prompts, and an H3 vs. peer model comparison.\n\nLinks:\n- Interactive atlas of all 1,000 H3 clips: https://neta.art/use-cases/en/h3-1000-prompt-list\n- Curated index repo: https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts\n- Original dataset (ostris/minimax_h3_1k): https://huggingface.co/datasets/ostris/minimax_h3_1k