### PR TITLE
Add AIVideoRunbook to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Unlike other lists that just dump links, this one answers the question developer
 - [wan-3.0-comfyui](https://github.com/Anil-matcha/wan-3.0-comfyui) — ComfyUI custom nodes for Wan 3.0 text-to-image, image edit, text-to-video, and image-to-video via MuAPI.
 - [Gemini-Omni-1.1-Flash-API](https://github.com/Anil-matcha/Gemini-Omni-1.1-Flash-API) — Python SDK and MCP server for Google's newly announced Gemini Omni 1.1 Flash update.
 - [Video-Utilities-API](https://github.com/Anil-matcha/Video-Utilities-API) — compare Muapi video upscaling and video-to-audio post-production endpoints.
+- [AIVideoRunbook](https://github.com/madebysaira/AIVideoRunbook) — offline-first credit-to-delivery orchestrator and quality catalog for AI video generation.
 
 ## Contents
 


### PR DESCRIPTION
## Summary

Adds [AIVideoRunbook](https://github.com/madebysaira/AIVideoRunbook) to **Related Projects**.

AIVideoRunbook is an offline-first CLI orchestrator for AI video generation that catalogs model calls, calculates true costs (sticker × retry overhead), and validates rendered clips against creative prompt contracts.

## Verification

- [x] Link verified (HTTP 200)
- [x] Matches section syntax: `- [Name](url) — description`
- [x] Clean single-line addition